### PR TITLE
fix: --base of lxc_ram should be '1024'

### DIFF
--- a/squeeze/lxc_ram
+++ b/squeeze/lxc_ram
@@ -58,7 +58,7 @@ fi
 if [ "$1" = "config" ]; then
 
  echo 'graph_title Memory '
- echo 'graph_args -l 0 --base 1000'
+ echo 'graph_args -l 0 --base 1024'
  echo 'graph_vlabel byte'
  echo 'graph_category lxc'
 


### PR DESCRIPTION
According to http://munin-monitoring.org/wiki/graph_args , --base should be 1024 for memory graph.
